### PR TITLE
Complete LD-V2200 CLV support

### DIFF
--- a/ddd-gui/src/gui/player_remote_dialog.cpp
+++ b/ddd-gui/src/gui/player_remote_dialog.cpp
@@ -695,15 +695,18 @@ void PlayerRemoteDialog::ApplyControls() {
   headline_->setText(PlayerStatusBarText(connection_, status_));
 
   for (const GatedButton& gated : command_buttons_) {
-    const bool available = live && controls.Has(gated.command);
+    const bool clv_still = status_.disc_type == player::DiscType::kClv &&
+                           gated.command == player::PlayerCommand::kStillFrame;
+    const bool available = live && controls.Has(gated.command) && !clv_still;
     gated.button->setEnabled(available);
 
     // A control that is not offered says why. The old application's silence
     // here is what made a capability the player lacked look like a fault in the
     // cable.
     gated.button->setToolTip(
-        available ? gated.help
-                  : UnsupportedControlNote(connection_, gated.command));
+        available   ? gated.help
+        : clv_still ? tr("Still frames are available only on CAV discs.")
+                    : UnsupportedControlNote(connection_, gated.command));
   }
 
   // The two parameterised commands. Their lists are rebuilt rather than merely

--- a/ddd-gui/src/gui/player_text.cpp
+++ b/ddd-gui/src/gui/player_text.cpp
@@ -468,7 +468,9 @@ QString PlayerCommandName(player::PlayerCommand command) {
     case player::PlayerCommand::kQueryActiveMode:
       return QObject::tr("Ask what the player is doing");
     case player::PlayerCommand::kQueryAddress:
-      return QObject::tr("Ask where the player is");
+      return QObject::tr("Ask where the player is by frame");
+    case player::PlayerCommand::kQueryTimeCode:
+      return QObject::tr("Ask where the player is by time");
     case player::PlayerCommand::kQueryDiscStatus:
       return QObject::tr("Ask about the disc");
     case player::PlayerCommand::kQueryStandardUserCode:

--- a/ddd-gui/src/gui/player_worker.cpp
+++ b/ddd-gui/src/gui/player_worker.cpp
@@ -506,20 +506,21 @@ void PlayerWorker::Poll() {
 
   status.disc_type = last_disc_type_;
 
-  // The address is read in the mode the disc implies. A disc whose type is not
-  // known yet is read as frames, which is what a CAV disc uses and what the
-  // parser will refuse outright if the reply turns out to be a time code — a
-  // refusal being much better than a number that is wrong by a factor of a
-  // hundred.
+  // The address is read from the register this definition uses for the disc's
+  // addressing mode. A disc whose type is not known yet falls back to the
+  // Frame Register: it is the CAV register and the parser will refuse an
+  // unexpected time code rather than turn it into a plausible, wrong frame.
   const player::Reply address =
-      session_->Execute(player::PlayerCommand::kQueryAddress);
+      session_->Execute(player::AddressQueryFor(
+          definition, player::AddressModeFor(status.disc_type)));
   if (address.status == player::ReplyStatus::kLinkFailed) {
     ReportLinkLost();
     return;
   }
   if (address.ok()) {
     status.address = player::ParseAddress(
-        address.text, player::AddressModeFor(status.disc_type));
+        address.text, player::AddressModeFor(status.disc_type),
+        definition.time_code_format);
   }
 
   if (session_->SupportsPhysicalPosition()) {

--- a/ddd-gui/src/gui/player_worker.cpp
+++ b/ddd-gui/src/gui/player_worker.cpp
@@ -510,9 +510,8 @@ void PlayerWorker::Poll() {
   // addressing mode. A disc whose type is not known yet falls back to the
   // Frame Register: it is the CAV register and the parser will refuse an
   // unexpected time code rather than turn it into a plausible, wrong frame.
-  const player::Reply address =
-      session_->Execute(player::AddressQueryFor(
-          definition, player::AddressModeFor(status.disc_type)));
+  const player::Reply address = session_->Execute(player::AddressQueryFor(
+      definition, player::AddressModeFor(status.disc_type)));
   if (address.status == player::ReplyStatus::kLinkFailed) {
     ReportLinkLost();
     return;

--- a/ddd-gui/src/player/auto_capture_sequence.cpp
+++ b/ddd-gui/src/player/auto_capture_sequence.cpp
@@ -94,7 +94,7 @@ AutoCaptureStep AutoCaptureSequence::StepFor(AutoCaptureStage stage) const {
       step.command = PlayCommand();
       break;
     case AutoCaptureStage::kWatching:
-      step.command = PlayerCommand::kQueryAddress;
+      step.command = AddressQueryFor(*definition_, plan_.addressing);
       step.delay = kWatchInterval;
       break;
     case AutoCaptureStage::kCheckingStall:
@@ -558,7 +558,8 @@ void AutoCaptureSequence::ApplyWatching(const Reply& reply) {
     return;
   }
 
-  const DiscAddress address = ParseAddress(reply.text, plan_.addressing);
+  const DiscAddress address =
+      ParseAddress(reply.text, plan_.addressing, definition_->time_code_format);
 
   if (address.in_lead_out) {
     // Past the end of the programme. The measured end may be a frame or two

--- a/ddd-gui/src/player/command_encoder.cpp
+++ b/ddd-gui/src/player/command_encoder.cpp
@@ -31,6 +31,29 @@ EncodedCommand Failure(EncodeStatus status) {
   return encoded;
 }
 
+// Turn the canonical HMMSSFF value that the application keeps into the
+// LD-V2200's HMMSS wire form. Frames are deliberately dropped: the player
+// cannot represent them in this form, and a capture plan's time bounds are
+// whole-second boundaries.
+std::optional<std::string> EncodeHMMSS(int32_t value) {
+  const int32_t hours = value / 1'000'000;
+  const int32_t minutes = (value / 10'000) % 100;
+  const int32_t seconds = (value / 100) % 100;
+
+  if (hours > 9 || minutes > 59 || seconds > 59) {
+    return std::nullopt;
+  }
+
+  std::string text;
+  text.reserve(5);
+  text.push_back(static_cast<char>('0' + hours));
+  text.push_back(static_cast<char>('0' + (minutes / 10)));
+  text.push_back(static_cast<char>('0' + (minutes % 10)));
+  text.push_back(static_cast<char>('0' + (seconds / 10)));
+  text.push_back(static_cast<char>('0' + (seconds % 10)));
+  return text;
+}
+
 // Look a parameter up in one of a definition's parameter tables and encode the
 // command it belongs to. Shared by the audio and speed entry points, which
 // differ only in which table they read.
@@ -72,7 +95,21 @@ EncodedCommand EncodeCommand(const PlayerDefinition& definition,
       return Failure(EncodeStatus::kArgumentOutOfRange);
     }
 
-    bytes += std::to_string(value);
+    switch (spec.argument) {
+      case ArgumentEncoding::kDecimal:
+        bytes += std::to_string(value);
+        break;
+      case ArgumentEncoding::kTimeCodeHMMSS: {
+        const std::optional<std::string> time_code = EncodeHMMSS(value);
+        if (!time_code.has_value()) {
+          return Failure(EncodeStatus::kArgumentOutOfRange);
+        }
+        bytes += *time_code;
+        break;
+      }
+      case ArgumentEncoding::kNone:
+        return Failure(EncodeStatus::kArgumentOutOfRange);
+    }
   }
 
   bytes += spec.suffix;

--- a/ddd-gui/src/player/disc_examiner.cpp
+++ b/ddd-gui/src/player/disc_examiner.cpp
@@ -211,7 +211,7 @@ ExamineStep DiscExaminer::StepFor(ExamineStage stage) const {
       break;
     case ExamineStage::kReadingEnd:
     case ExamineStage::kReadingStart:
-      step.command = PlayerCommand::kQueryAddress;
+      step.command = AddressQueryFor(*definition_, addressing());
       break;
     case ExamineStage::kSettling:
       step.command = PlayerCommand::kPause;
@@ -292,10 +292,12 @@ void DiscExaminer::Apply(const Reply& reply) {
       ApplyTvSystem(reply);
       break;
     case ExamineStage::kReadingPioneerUserCode:
-      ApplyUserCode(reply, profile_.pioneer_user_code);
+      ApplyUserCode(reply, profile_.pioneer_user_code,
+                    definition_->user_code_error_policy);
       break;
     case ExamineStage::kReadingStandardUserCode:
-      ApplyUserCode(reply, profile_.standard_user_code);
+      ApplyUserCode(reply, profile_.standard_user_code,
+                    definition_->user_code_error_policy);
       break;
     case ExamineStage::kCheckingChapters:
       ApplyChapters(reply);
@@ -454,12 +456,16 @@ void DiscExaminer::ApplyTvSystem(const Reply& reply) {
   profile_.video_standard.Record(system.disc, Provenance::kReported);
 }
 
-void DiscExaminer::ApplyUserCode(const Reply& reply, UserCodeReading& into) {
+void DiscExaminer::ApplyUserCode(const Reply& reply, UserCodeReading& into,
+                                 UserCodeErrorPolicy error_policy) {
   if (reply.ok() && IsErrorCode(reply.text)) {
-    // "E04" and the like. The LD-V4400 manual documents it as no user code
-    // being encoded on the disc, which is a fact about the disc and not a fault
-    // — so it is recorded rather than discarded, and the report says which.
-    into.outcome = UserCodeReading::Outcome::kNotEncoded;
+    // "E04" and the like. The Level III manuals document it as no user code
+    // encoded on the disc, but the LD-V2200's meaning has not been established.
+    // Preserve the reply either way; only definitions with documented semantics
+    // turn it into a fact about the disc.
+    into.outcome = error_policy == UserCodeErrorPolicy::kNotEncoded
+                       ? UserCodeReading::Outcome::kNotEncoded
+                       : UserCodeReading::Outcome::kRefused;
     into.text = reply.text;
     return;
   }
@@ -493,7 +499,8 @@ void DiscExaminer::ApplyEndAddress(const Reply& reply) {
     return;
   }
 
-  const DiscAddress address = ParseAddress(reply.text, addressing());
+  const DiscAddress address =
+      ParseAddress(reply.text, addressing(), definition_->time_code_format);
   if (address.valid) {
     profile_.programme_end.Record(address.value, Provenance::kMeasured);
   }
@@ -504,7 +511,8 @@ void DiscExaminer::ApplyStartAddress(const Reply& reply) {
     return;
   }
 
-  const DiscAddress address = ParseAddress(reply.text, addressing());
+  const DiscAddress address =
+      ParseAddress(reply.text, addressing(), definition_->time_code_format);
 
   // Only where the reply said something about where the player is. A reply that
   // carried neither an address nor a lead-in marker says nothing, and recording

--- a/ddd-gui/src/player/disc_examiner.h
+++ b/ddd-gui/src/player/disc_examiner.h
@@ -249,7 +249,8 @@ class DiscExaminer {
   void ApplySpinningUp(const Reply& reply);
   void ApplyDiscStatus(const Reply& reply);
   void ApplyTvSystem(const Reply& reply);
-  void ApplyUserCode(const Reply& reply, UserCodeReading& into);
+  void ApplyUserCode(const Reply& reply, UserCodeReading& into,
+                     UserCodeErrorPolicy error_policy);
   void ApplyChapters(const Reply& reply);
   void ApplyEndAddress(const Reply& reply);
   void ApplyStartAddress(const Reply& reply);

--- a/ddd-gui/src/player/player_command.h
+++ b/ddd-gui/src/player/player_command.h
@@ -91,7 +91,13 @@ enum class PlayerCommand : uint8_t {
 
   // Queries
   kQueryActiveMode,
+
+  // The Frame Register query. It returns five-digit CAV frame addresses and,
+  // on normal Pioneer Level III CLV players, seven-digit extended time codes.
+  // Models such as the LD-V2200 that instead expose only a Time Register use
+  // kQueryTimeCode; AddressQueryFor() chooses between the two.
   kQueryAddress,
+  kQueryTimeCode,
   kQueryDiscStatus,
   kQueryStandardUserCode,
   kQueryPioneerUserCode,
@@ -151,14 +157,18 @@ inline constexpr int8_t kParameterUnsupported = -1;
 
 // How a command's argument is written.
 //
-// One encoding, because one is what the Pioneer command set uses: the argument
-// is decimal and unpadded, so a seek to frame 1 is "FR1SE" and not "FR00001SE".
-// A model needing zero padding would be a new encoding here and a change to one
-// function in command_encoder.cpp; adding it before anything needs it would be
-// a code path nothing exercises.
+// The ordinary Pioneer argument is decimal and unpadded, so a seek to frame 1
+// is "FR1SE" and not "FR00001SE". Some models use a different wire form for
+// CLV time codes; that is an encoding rather than a special case in the
+// transport, so it belongs in a model's command definition.
 enum class ArgumentEncoding : uint8_t {
   kNone,
   kDecimal,
+
+  // The application's canonical time code is HMMSSFF. This writes the same
+  // position as a five-digit, zero-padded HMMSS address, dropping its frame
+  // field. The LD-V2200 uses this form with the TM command.
+  kTimeCodeHMMSS,
 };
 
 // What kind of answer the command produces.
@@ -258,6 +268,20 @@ constexpr CommandSpec CommandWithArgument(
   spec.suffix = suffix;
   spec.argument = ArgumentEncoding::kDecimal;
   spec.argument_digits = digits;
+  spec.timeout = timeout;
+  return spec;
+}
+
+// A time-code command whose argument enters as the application's canonical
+// seven-digit HMMSSFF form and leaves as the model's five-digit HMMSS form.
+constexpr CommandSpec CommandWithHMMSSArgument(
+    std::string_view prefix, std::string_view suffix,
+    TimeoutClass timeout = TimeoutClass::kNormal) {
+  CommandSpec spec;
+  spec.prefix = prefix;
+  spec.suffix = suffix;
+  spec.argument = ArgumentEncoding::kTimeCodeHMMSS;
+  spec.argument_digits = 7;
   spec.timeout = timeout;
   return spec;
 }

--- a/ddd-gui/src/player/player_definition.h
+++ b/ddd-gui/src/player/player_definition.h
@@ -159,6 +159,26 @@ struct TvSystemDecode {
   ReplyField external_sync{.index = 2};
 };
 
+// The representation a player uses for a CLV address on the wire. The
+// application always keeps a time code as HMMSSFF so that every model's
+// profile, plan and report use one common value; this only describes the
+// serial protocol at a player's boundary.
+enum class TimeCodeFormat : uint8_t {
+  kHMMSSFF,
+  kHMMSS,
+};
+
+// What an error reply to either user-code request establishes.
+//
+// The Level III manuals document an error as a disc with no code encoded, but
+// that is not evidence that every player uses it that way. Definitions whose
+// hardware has not established the meaning retain the reply without making a
+// claim about the disc.
+enum class UserCodeErrorPolicy : uint8_t {
+  kNotEncoded,
+  kUnsupported,
+};
+
 // One player model, entirely as data.
 //
 // No virtuals and no per-model subclass: a definition is a value a header
@@ -218,6 +238,19 @@ struct PlayerDefinition {
   StateDecode state_decode;
   DiscStatusDecode disc_status;
   TvSystemDecode tv_system;
+
+  // The CLV address form in replies. Normal Level III players return their
+  // frame-precise HMMSSFF address through the Frame Register (?F); the
+  // LD-V2200 returns HMMSS through its Time Register (?T). This records both
+  // the form ParseAddress() receives and which register AddressQueryFor()
+  // must read. The command table independently records the form used when a
+  // time-code search is sent.
+  TimeCodeFormat time_code_format = TimeCodeFormat::kHMMSSFF;
+
+  // The meaning of a user-code query's error reply. Both user-code requests
+  // share the Level III convention unless a model's observed behaviour says
+  // otherwise.
+  UserCodeErrorPolicy user_code_error_policy = UserCodeErrorPolicy::kNotEncoded;
 };
 
 // The command table entry for one command. Not present() when the model does
@@ -225,6 +258,22 @@ struct PlayerDefinition {
 constexpr const CommandSpec& Spec(const PlayerDefinition& definition,
                                   PlayerCommand command) {
   return definition.commands[Index(command)];
+}
+
+// Which register reports an address in this mode for this definition.
+//
+// Pioneer Level III's Frame Register is not CAV-only: on the usual CLV players
+// ?F returns the extended HMMSSFF address, including the frame field that a
+// capture needs. The LD-V2200 is the observed exception. Its CLV ?F request is
+// refused and its Time Register (?T) returns the shorter HMMSS form instead.
+// Keeping that distinction with the definition prevents an LD-V2200 fix from
+// silently dropping frame precision on every other Pioneer model.
+constexpr PlayerCommand AddressQueryFor(const PlayerDefinition& definition,
+                                        AddressMode mode) {
+  return mode == AddressMode::kTimeCode &&
+                 definition.time_code_format == TimeCodeFormat::kHMMSS
+             ? PlayerCommand::kQueryTimeCode
+             : PlayerCommand::kQueryAddress;
 }
 
 // Does this model, running this firmware, report a physical position?
@@ -347,10 +396,11 @@ constexpr bool IsConsistent(const PlayerDefinition& definition) {
     return false;
   }
 
-  // The three queries the application cannot work without: what the player is
-  // doing, where it is, and what disc it has.
+  // The queries the application cannot work without: what the player is doing,
+  // where it is in both address forms, and what disc it has.
   return Spec(definition, PlayerCommand::kQueryActiveMode).present() &&
          Spec(definition, PlayerCommand::kQueryAddress).present() &&
+         Spec(definition, PlayerCommand::kQueryTimeCode).present() &&
          Spec(definition, PlayerCommand::kQueryDiscStatus).present() &&
          !definition.state_decode.mappings.empty();
 }

--- a/ddd-gui/src/player/players/pioneer_ld_v2200.h
+++ b/ddd-gui/src/player/players/pioneer_ld_v2200.h
@@ -16,11 +16,18 @@
 
 namespace ddd::player::pioneer {
 
-// Inherits the Level III set unchanged; not yet bench-verified.
+// The LD-V2200's CLV time code has no frame field. It reports HMMSS over the
+// serial link and accepts the same five digits after TM for a time-code seek;
+// the rest of the Level III command set is inherited. This narrow observation
+// does not replace the full bench checklist, so bench_verified stays false.
 inline constexpr PlayerDefinition kLdV2200 = [] {
   PlayerDefinition definition = LevelIII();
   definition.name = "Pioneer LD-V2200";
   definition.id_code = "07";
+  definition.time_code_format = TimeCodeFormat::kHMMSS;
+  definition.user_code_error_policy = UserCodeErrorPolicy::kUnsupported;
+  definition.commands[Index(PlayerCommand::kSeekTimeCode)] =
+      CommandWithHMMSSArgument("TM", "SE", TimeoutClass::kLong);
   return definition;
 }();
 

--- a/ddd-gui/src/player/players/pioneer_level_iii.h
+++ b/ddd-gui/src/player/players/pioneer_level_iii.h
@@ -152,6 +152,7 @@ constexpr PlayerDefinition LevelIII() {
   // bytes and may perfectly well contain an 'E'.
   commands[Index(PlayerCommand::kQueryActiveMode)] = Query("?P");
   commands[Index(PlayerCommand::kQueryAddress)] = Query("?F");
+  commands[Index(PlayerCommand::kQueryTimeCode)] = Query("?T");
   commands[Index(PlayerCommand::kQueryDiscStatus)] = Query("?D");
   commands[Index(PlayerCommand::kQueryStandardUserCode)] = Query("$Y");
 

--- a/ddd-gui/src/player/response_parser.cpp
+++ b/ddd-gui/src/player/response_parser.cpp
@@ -40,10 +40,13 @@ std::string_view LeadingDigits(std::string_view text) {
   return text.substr(0, length);
 }
 
-// How many digits an address may have in this mode. Five is a CAV frame number
-// and seven a CLV time code, which is the Pioneer address format.
-size_t AddressDigits(AddressMode mode) {
-  return mode == AddressMode::kTimeCode ? 7 : 5;
+// How many significant digits an address may have. CAV frame numbers are five
+// digits; a CLV time code is either the usual HMMSSFF or the LD-V2200's HMMSS.
+size_t AddressDigits(AddressMode mode, TimeCodeFormat time_code_format) {
+  if (mode == AddressMode::kFrame) {
+    return 5;
+  }
+  return time_code_format == TimeCodeFormat::kHMMSS ? 5 : 7;
 }
 
 // The player's error code, if the refusal carried a legible one.
@@ -137,7 +140,8 @@ bool IsErrorCode(std::string_view text) {
   return std::all_of(text.begin() + 1, text.end(), IsDigit);
 }
 
-DiscAddress ParseAddress(std::string_view raw, AddressMode mode) {
+DiscAddress ParseAddress(std::string_view raw, AddressMode mode,
+                         TimeCodeFormat time_code_format) {
   DiscAddress address;
 
   std::string text = StripTerminator(raw);
@@ -170,13 +174,21 @@ DiscAddress ParseAddress(std::string_view raw, AddressMode mode) {
                ? digits.substr(digits.size() - 1)
                : digits.substr(first_significant);
 
-  if (digits.size() > AddressDigits(mode)) {
+  if (digits.size() > AddressDigits(mode, time_code_format)) {
     return address;
   }
 
   int32_t value = 0;
   for (const char digit : digits) {
     value = (value * 10) + (digit - '0');
+  }
+
+  // HMMSS is right-aligned in exactly the same way as the canonical HMMSSFF
+  // form. Multiplying restores its absent frame field, so the rest of the
+  // application never has to care which serial representation supplied it.
+  if (mode == AddressMode::kTimeCode &&
+      time_code_format == TimeCodeFormat::kHMMSS) {
+    value *= 100;
   }
 
   address.valid = true;

--- a/ddd-gui/src/player/response_parser.h
+++ b/ddd-gui/src/player/response_parser.h
@@ -158,7 +158,9 @@ struct DiscAddress {
 // and the old application would silently take the first five digits of one and
 // report it as a frame; here a reply with more digits than the mode allows is
 // unparseable instead.
-DiscAddress ParseAddress(std::string_view raw, AddressMode mode);
+DiscAddress ParseAddress(
+    std::string_view raw, AddressMode mode,
+    TimeCodeFormat time_code_format = TimeCodeFormat::kHMMSSFF);
 
 // Read an active-mode reply through a model's state table.
 PlayerState ParsePlayerState(std::string_view raw, const StateDecode& decode);

--- a/ddd-gui/tests/gui/unit/test_player_controller.cpp
+++ b/ddd-gui/tests/gui/unit/test_player_controller.cpp
@@ -33,9 +33,10 @@ using namespace std::chrono_literals;
 
 constexpr const char* kPortPath = "/dev/ttyFAKE0";
 
-// An LD-V4300D — the model on the project's own bench — and an LD-V8000, for
-// the cases that need two different players.
+// An LD-V4300D — the model on the project's own bench — an LD-V2200 and an
+// LD-V8000, for the cases that need different players.
 constexpr const char* kLdV4300DReply = "P1515A1";
+constexpr const char* kLdV2200Reply = "P1507A1";
 constexpr const char* kLdV8000Reply = "P1506A9";
 
 // Pump the event loop until a condition holds, so a test fails with a message
@@ -284,9 +285,10 @@ TEST_F(PlayerControllerTest, TheStatusIsPolledAndReadInTheDiscsOwnTerms) {
   EXPECT_EQ(status.address.value, 12345);
 }
 
-TEST_F(PlayerControllerTest, ACavAddressAndAClvAddressAreBothRead) {
-  // A CLV time code is seven digits, and reading it as a frame number would be
-  // wrong by orders of magnitude — so the mode has to follow the disc.
+TEST_F(PlayerControllerTest, ANormalClvAddressIsReadWithTheFrameQuery) {
+  // Pioneer Level III uses the Frame Register for its frame-precise CLV
+  // address. The LD-V2200's ?T/HMMSS behaviour is an exception, not a change
+  // to this documented path.
   port_.AddPioneerPlayer(9600, kLdV4300DReply);
   port_.AddStatusResponses(9600, "P04", "11011", "1234500");
   BuildController();
@@ -299,6 +301,50 @@ TEST_F(PlayerControllerTest, ACavAddressAndAClvAddressAreBothRead) {
   }));
 
   EXPECT_EQ(controller_->status().address.value, 1234500);
+
+  const std::vector<std::string> writes = port_.writes();
+  EXPECT_NE(std::find(writes.begin(), writes.end(), "?F\r"), writes.end());
+  EXPECT_EQ(std::find(writes.begin(), writes.end(), "?T\r"), writes.end());
+}
+
+TEST_F(PlayerControllerTest, AnLdV2200ClvAddressIsReadWithTheTimeQuery) {
+  // The LD-V2200 refuses ?F for a CLV disc and returns HMMSS from ?T, so this
+  // model selects the Time Register and restores its absent frame field.
+  port_.AddPioneerPlayer(9600, kLdV2200Reply);
+  port_.AddStatusResponses(9600, "P04", "11011", "00002",
+                           player::PlayerCommand::kQueryTimeCode);
+  BuildController();
+  Enable();
+
+  ASSERT_TRUE(WaitForState(PlayerConnectionState::kConnected));
+  ASSERT_TRUE(PumpUntil([this] {
+    return controller_->status().disc_type == player::DiscType::kClv &&
+           controller_->status().address.valid;
+  }));
+
+  EXPECT_EQ(controller_->status().address.value, 200);
+
+  const std::vector<std::string> writes = port_.writes();
+  EXPECT_NE(std::find(writes.begin(), writes.end(), "?T\r"), writes.end());
+  EXPECT_EQ(std::find(writes.begin(), writes.end(), "?F\r"), writes.end());
+}
+
+TEST_F(PlayerControllerTest, AnUnknownDiscTypeKeepsTheFrameQueryFallback) {
+  port_.AddPioneerPlayer(9600, kLdV4300DReply);
+  port_.AddStatusResponses(9600, "P04", "1X001", "0012345");
+  BuildController();
+  Enable();
+
+  ASSERT_TRUE(WaitForState(PlayerConnectionState::kConnected));
+  ASSERT_TRUE(
+      PumpUntil([this] { return controller_->status().address.valid; }));
+
+  EXPECT_EQ(controller_->status().disc_type, player::DiscType::kUnknown);
+  EXPECT_EQ(controller_->status().address.value, 12345);
+
+  const std::vector<std::string> writes = port_.writes();
+  EXPECT_NE(std::find(writes.begin(), writes.end(), "?F\r"), writes.end());
+  EXPECT_EQ(std::find(writes.begin(), writes.end(), "?T\r"), writes.end());
 }
 
 TEST_F(PlayerControllerTest, ALinkThatDiesIsReportedAndSearchedForAgain) {

--- a/ddd-gui/tests/gui/widget/test_player_remote_dialog.cpp
+++ b/ddd-gui/tests/gui/widget/test_player_remote_dialog.cpp
@@ -409,6 +409,31 @@ TEST_F(PlayerRemoteDialogTest, TheAddressingFollowsTheDisc) {
   EXPECT_FALSE(offers(player::PlayerCommand::kSeekTimeCode));
 }
 
+TEST_F(PlayerRemoteDialogTest, StillIsEnabledOnlyForCavOrAnUnknownDisc) {
+  BuildBare();
+  dialog_->SetConnection(ConnectionTo(LdV4300D()));
+
+  auto* still = Find<QPushButton>(PlayerRemoteDialog::kStillButtonName);
+  ASSERT_NE(still, nullptr);
+  EXPECT_TRUE(still->isEnabled());
+
+  player::PlayerStatus clv;
+  // A failed mode query must not enable a command when the separate disc
+  // status query has still identified the disc as CLV.
+  clv.disc_type = player::DiscType::kClv;
+  dialog_->SetStatus(clv);
+
+  EXPECT_FALSE(still->isEnabled());
+  EXPECT_TRUE(still->toolTip().contains(QStringLiteral("CAV")));
+
+  player::PlayerStatus cav;
+  cav.valid = true;
+  cav.disc_type = player::DiscType::kCav;
+  dialog_->SetStatus(cav);
+
+  EXPECT_TRUE(still->isEnabled());
+}
+
 TEST_F(PlayerRemoteDialogTest, AControlTheModelLacksIsDisabledAndSaysWhy) {
   // The old dialog offered every button to every player, so a control the
   // player did not have was present, enabled, and silently did nothing.

--- a/ddd-gui/tests/player/test_auto_capture_sequence.cpp
+++ b/ddd-gui/tests/player/test_auto_capture_sequence.cpp
@@ -19,6 +19,7 @@
 
 #include "auto_capture_sequence.h"
 #include "player_registry.h"
+#include "players/pioneer_ld_v2200.h"
 
 namespace ddd::player {
 namespace {
@@ -276,6 +277,13 @@ TEST(AutoCaptureSequence, AWholeCavSideSpinsDownBeforeItStartsWriting) {
       std::find(stages.begin(), stages.end(), AutoCaptureStage::kSpinningUp);
   EXPECT_LT(spin_down, start);
   EXPECT_LT(start, spin_up);
+
+  const auto watch =
+      std::find_if(steps.begin(), steps.end(), [](const AutoCaptureStep& step) {
+        return step.stage == AutoCaptureStage::kWatching;
+      });
+  ASSERT_NE(watch, steps.end());
+  EXPECT_EQ(watch->command, PlayerCommand::kQueryAddress);
 }
 
 TEST(AutoCaptureSequence, ACavSideIsPlayedWithItsStopCodesIgnored) {
@@ -298,7 +306,7 @@ TEST(AutoCaptureSequence, ACavSideIsPlayedWithItsStopCodesIgnored) {
   EXPECT_EQ(spin_up->command, PlayerCommand::kPlayWithoutStopCodes);
 }
 
-TEST(AutoCaptureSequence, AClvSideIsSimplyPlayed) {
+TEST(AutoCaptureSequence, ANormalClvSideIsSimplyPlayedAndWatchedByFrameAddress) {
   const DiscProfile disc = ClvDisc();
   AutoCaptureSequence sequence(LevelIIIModel(), "02", WholeSide(disc), disc);
 
@@ -325,6 +333,27 @@ TEST(AutoCaptureSequence, AClvSideIsSimplyPlayed) {
       });
   ASSERT_NE(watch, steps.end());
   EXPECT_EQ(watch->command, PlayerCommand::kQueryAddress);
+}
+
+TEST(AutoCaptureSequence, AnLdV2200ClvSideIsWatchedByTimeCode) {
+  const DiscProfile disc = ClvDisc();
+  AutoCaptureSequence sequence(pioneer::kLdV2200, "02", WholeSide(disc),
+                               disc);
+
+  Script script;
+  script.answers[AutoCaptureStage::kConfirmingDisc] = Answered("11001");
+  script.addresses = {"<00000", "05045"};
+
+  const std::vector<AutoCaptureStep> steps = Drive(sequence, script);
+
+  EXPECT_EQ(sequence.outcome(), AutoCaptureOutcome::kCompleted);
+
+  const auto watch =
+      std::find_if(steps.begin(), steps.end(), [](const AutoCaptureStep& step) {
+        return step.stage == AutoCaptureStage::kWatching;
+      });
+  ASSERT_NE(watch, steps.end());
+  EXPECT_EQ(watch->command, PlayerCommand::kQueryTimeCode);
 }
 
 // --- The stop that opens the tray ------------------------------------------

--- a/ddd-gui/tests/player/test_auto_capture_sequence.cpp
+++ b/ddd-gui/tests/player/test_auto_capture_sequence.cpp
@@ -306,7 +306,8 @@ TEST(AutoCaptureSequence, ACavSideIsPlayedWithItsStopCodesIgnored) {
   EXPECT_EQ(spin_up->command, PlayerCommand::kPlayWithoutStopCodes);
 }
 
-TEST(AutoCaptureSequence, ANormalClvSideIsSimplyPlayedAndWatchedByFrameAddress) {
+TEST(AutoCaptureSequence,
+     ANormalClvSideIsSimplyPlayedAndWatchedByFrameAddress) {
   const DiscProfile disc = ClvDisc();
   AutoCaptureSequence sequence(LevelIIIModel(), "02", WholeSide(disc), disc);
 
@@ -337,8 +338,7 @@ TEST(AutoCaptureSequence, ANormalClvSideIsSimplyPlayedAndWatchedByFrameAddress) 
 
 TEST(AutoCaptureSequence, AnLdV2200ClvSideIsWatchedByTimeCode) {
   const DiscProfile disc = ClvDisc();
-  AutoCaptureSequence sequence(pioneer::kLdV2200, "02", WholeSide(disc),
-                               disc);
+  AutoCaptureSequence sequence(pioneer::kLdV2200, "02", WholeSide(disc), disc);
 
   Script script;
   script.answers[AutoCaptureStage::kConfirmingDisc] = Answered("11001");

--- a/ddd-gui/tests/player/test_command_encoder.cpp
+++ b/ddd-gui/tests/player/test_command_encoder.cpp
@@ -18,6 +18,7 @@
 #include "player_command.h"
 #include "player_definition.h"
 #include "player_registry.h"
+#include "players/pioneer_ld_v2200.h"
 #include "players/pioneer_ld_v4300d.h"
 #include "players/pioneer_ld_v8000.h"
 
@@ -63,6 +64,7 @@ constexpr ExpectedCommand kLevelIIIWireFormat[] = {
 
     {PlayerCommand::kQueryActiveMode, "?P\r"},
     {PlayerCommand::kQueryAddress, "?F\r"},
+    {PlayerCommand::kQueryTimeCode, "?T\r"},
     {PlayerCommand::kQueryDiscStatus, "?D\r"},
     {PlayerCommand::kQueryStandardUserCode, "$Y\r"},
     {PlayerCommand::kQueryPioneerUserCode, "?U\r"},
@@ -111,6 +113,24 @@ TEST(CommandEncoderTest, AddressesAreDecimalAndUnpadded) {
 
   EXPECT_EQ(EncodeCommand(player, PlayerCommand::kSeekChapter, 12).bytes,
             "CH12SE\r");
+}
+
+TEST(CommandEncoderTest, TheLdV2200UsesItsOwnClvTimeCodeForm) {
+  const PlayerDefinition& player = pioneer::kLdV2200;
+
+  // The application keeps HMMSSFF internally, while this player accepts a
+  // fixed-width HMMSS address after TM.
+  EXPECT_EQ(EncodeCommand(player, PlayerCommand::kSeekTimeCode, 10000).bytes,
+            "TM00100SE\r");
+  EXPECT_EQ(EncodeCommand(player, PlayerCommand::kSeekTimeCode, 1595900).bytes,
+            "TM15959SE\r");
+
+  // A player report can carry a frame number even though the next seek cannot;
+  // it remains a seek to the reported second rather than a malformed command.
+  EXPECT_EQ(EncodeCommand(player, PlayerCommand::kSeekTimeCode, 1234517).bytes,
+            "TM12345SE\r");
+  EXPECT_EQ(EncodeCommand(player, PlayerCommand::kSeekTimeCode, 1239999).status,
+            EncodeStatus::kArgumentOutOfRange);
 }
 
 TEST(CommandEncoderTest, TheArgumentCanComeFirst) {

--- a/ddd-gui/tests/player/test_disc_examiner.cpp
+++ b/ddd-gui/tests/player/test_disc_examiner.cpp
@@ -19,6 +19,7 @@
 
 #include "disc_examiner.h"
 #include "player_registry.h"
+#include "players/pioneer_ld_v2200.h"
 #include "players/pioneer_level_iii.h"
 
 namespace ddd::player {
@@ -250,9 +251,18 @@ TEST(DiscExaminerTest, ACavDiscIsSeekedByFrameWithTheOldApplicationsAddresses) {
   ASSERT_NE(start, nullptr);
   EXPECT_EQ(start->command, PlayerCommand::kSeekFrame);
   EXPECT_EQ(start->argument.value_or(-1), 1);
+
+  const ExamineStep* const end_address = Find(sent, ExamineStage::kReadingEnd);
+  ASSERT_NE(end_address, nullptr);
+  EXPECT_EQ(end_address->command, PlayerCommand::kQueryAddress);
+
+  const ExamineStep* const start_address =
+      Find(sent, ExamineStage::kReadingStart);
+  ASSERT_NE(start_address, nullptr);
+  EXPECT_EQ(start_address->command, PlayerCommand::kQueryAddress);
 }
 
-TEST(DiscExaminerTest, AClvDiscIsSeekedByTimeCodeInstead) {
+TEST(DiscExaminerTest, ANormalClvDiscIsSeekedByTimeCodeAndReadByFrameAddress) {
   DiscExaminer examiner(LevelIIIModel(), "A1");
   const std::vector<ExamineStep> sent = Drive(examiner, ClvScript());
 
@@ -260,6 +270,34 @@ TEST(DiscExaminerTest, AClvDiscIsSeekedByTimeCodeInstead) {
   ASSERT_NE(end, nullptr);
   EXPECT_EQ(end->command, PlayerCommand::kSeekTimeCode);
   EXPECT_EQ(end->argument.value_or(-1), 1595900);
+
+  const ExamineStep* const end_address = Find(sent, ExamineStage::kReadingEnd);
+  ASSERT_NE(end_address, nullptr);
+  EXPECT_EQ(end_address->command, PlayerCommand::kQueryAddress);
+
+  const ExamineStep* const start_address =
+      Find(sent, ExamineStage::kReadingStart);
+  ASSERT_NE(start_address, nullptr);
+  EXPECT_EQ(start_address->command, PlayerCommand::kQueryAddress);
+}
+
+TEST(DiscExaminerTest, AnLdV2200ClvDiscIsReadByTimeCode) {
+  DiscExaminer examiner(pioneer::kLdV2200, "A1");
+  Script script = ClvScript();
+  script[ExamineStage::kReadingEnd] = Answered("05045");
+  script[ExamineStage::kReadingStart] = Answered("<00000");
+  const std::vector<ExamineStep> sent = Drive(examiner, script);
+
+  const ExamineStep* const end_address = Find(sent, ExamineStage::kReadingEnd);
+  ASSERT_NE(end_address, nullptr);
+  EXPECT_EQ(end_address->command, PlayerCommand::kQueryTimeCode);
+
+  const ExamineStep* const start_address =
+      Find(sent, ExamineStage::kReadingStart);
+  ASSERT_NE(start_address, nullptr);
+  EXPECT_EQ(start_address->command, PlayerCommand::kQueryTimeCode);
+
+  EXPECT_EQ(examiner.profile().programme_end.value, 504500);
 }
 
 TEST(DiscExaminerTest, APlayerAlreadyPlayingIsNotSpunUpAgain) {
@@ -771,6 +809,23 @@ TEST(DiscExaminerTest, AnErrorCodeIsRecordedAsNoUserCodeRatherThanAsOne) {
   EXPECT_EQ(code.outcome, UserCodeReading::Outcome::kNotEncoded);
   EXPECT_FALSE(code.read());
   EXPECT_EQ(code.text, "E04");
+}
+
+TEST(DiscExaminerTest, TheLdV2200DoesNotClaimAnErrorMeansTheDiscHasNoUserCode) {
+  DiscExaminer examiner(pioneer::kLdV2200, "A1");
+  Script script = ClvScript();
+  script[ExamineStage::kReadingEnd] = Answered("04448");
+  script[ExamineStage::kReadingStart] = Answered("<00000");
+  script[ExamineStage::kReadingPioneerUserCode] = Answered("E04");
+  script[ExamineStage::kReadingStandardUserCode] = Answered("E04");
+  Drive(examiner, script);
+
+  for (const UserCodeReading* code : {&examiner.profile().pioneer_user_code,
+                                      &examiner.profile().standard_user_code}) {
+    EXPECT_EQ(code->outcome, UserCodeReading::Outcome::kRefused);
+    EXPECT_FALSE(code->read());
+    EXPECT_EQ(code->text, "E04");
+  }
 }
 
 TEST(DiscExaminerTest, AUserCodeTheDiscHasIsRecordedEvenWhereItCouldNotBeRead) {

--- a/ddd-gui/tests/player/test_player_controls.cpp
+++ b/ddd-gui/tests/player/test_player_controls.cpp
@@ -179,7 +179,7 @@ TEST(PlayerControlsTest, EveryRegisteredModelOffersWhatTheApplicationNeeds) {
          {PlayerCommand::kPlay, PlayerCommand::kPause, PlayerCommand::kStop,
           PlayerCommand::kSeekFrame, PlayerCommand::kSeekTimeCode,
           PlayerCommand::kQueryActiveMode, PlayerCommand::kQueryAddress,
-          PlayerCommand::kQueryDiscStatus}) {
+          PlayerCommand::kQueryTimeCode, PlayerCommand::kQueryDiscStatus}) {
       EXPECT_TRUE(controls.Has(command))
           << definition->name << " cannot be asked for command index "
           << Index(command);

--- a/ddd-gui/tests/player/test_player_registry.cpp
+++ b/ddd-gui/tests/player/test_player_registry.cpp
@@ -140,6 +140,7 @@ TEST(PlayerRegistryTest, TheGenericPlayerIsUsableButDoesNotClaimToBeAModel) {
   // it: an unrecognised player can still be driven.
   EXPECT_TRUE(Spec(generic, PlayerCommand::kPlay).present());
   EXPECT_TRUE(Spec(generic, PlayerCommand::kQueryAddress).present());
+  EXPECT_TRUE(Spec(generic, PlayerCommand::kQueryTimeCode).present());
 }
 
 TEST(PlayerRegistryTest, NoDefinitionClaimsEvidenceItDoesNotHave) {
@@ -184,6 +185,13 @@ TEST(PlayerRegistryTest, AnInconsistentDefinitionIsRejected) {
   // a model genuinely lacking frame search would look like.
   missing_command.capabilities.frame_search = false;
   EXPECT_TRUE(IsConsistent(missing_command));
+
+  // Both address queries are required even though neither is a user-facing
+  // control: the application selects one after it learns the disc's type.
+  PlayerDefinition missing_time_query = pioneer::kLdV4300D;
+  missing_time_query.commands[Index(PlayerCommand::kQueryTimeCode)] =
+      CommandSpec{};
+  EXPECT_FALSE(IsConsistent(missing_time_query));
 
   // Takes an argument without saying how wide it may be.
   PlayerDefinition widthless = pioneer::kLdV4300D;

--- a/ddd-gui/tests/player/test_player_session.cpp
+++ b/ddd-gui/tests/player/test_player_session.cpp
@@ -17,6 +17,7 @@
 #include "fake_serial_port.h"
 #include "player_registry.h"
 #include "player_session.h"
+#include "players/pioneer_ld_v2200.h"
 #include "players/pioneer_ld_v4300d.h"
 #include "players/pioneer_ld_v8000.h"
 
@@ -29,6 +30,10 @@ constexpr const char* kLdV8000Reply = "P1506A9";
 
 // An LD-V4300D, for the cases that want a player without that capability.
 constexpr const char* kLdV4300DReply = "P1515A1";
+
+// An LD-V2200, whose CLV time-code wire format differs from the Level III
+// default.
+constexpr const char* kLdV2200Reply = "P1507A1";
 
 class PlayerSessionTest : public testing::Test {
  protected:
@@ -265,6 +270,24 @@ TEST_F(PlayerSessionTest, ACommandIsSentAndItsAcknowledgementRead) {
 
   EXPECT_EQ(reply.status, ReplyStatus::kOk);
   EXPECT_EQ(port_.writes().back(), "PL\r");
+}
+
+TEST_F(PlayerSessionTest, TheLdV2200ProfileIsSelectedAndEncodesItsTimeCode) {
+  ConnectAt(9600, kLdV2200Reply);
+  ASSERT_EQ(session_.identity().definition, &pioneer::kLdV2200);
+  port_.AddResponse(9600, "TM00100SE\r", "R\r");
+  port_.AddResponse(9600, "?T\r", "00002\r");
+
+  const Reply reply = session_.Execute(PlayerCommand::kSeekTimeCode, 10000);
+
+  EXPECT_EQ(reply.status, ReplyStatus::kOk);
+  EXPECT_EQ(reply.sent, "TM00100SE\r");
+  EXPECT_EQ(port_.writes().back(), "TM00100SE\r");
+
+  const Reply address = session_.Execute(PlayerCommand::kQueryTimeCode);
+  EXPECT_EQ(address.status, ReplyStatus::kOk);
+  EXPECT_EQ(address.sent, "?T\r");
+  EXPECT_EQ(address.text, "00002");
 }
 
 TEST_F(PlayerSessionTest, EveryReplyCarriesTheBytesThatProvokedIt) {

--- a/ddd-gui/tests/player/test_response_parser.cpp
+++ b/ddd-gui/tests/player/test_response_parser.cpp
@@ -133,6 +133,16 @@ TEST(ResponseParserTest, ATimeCodeIsReadInTimeCodeMode) {
   EXPECT_EQ(address.value, 1234500);
 }
 
+TEST(ResponseParserTest, AShortTimeCodeIsExpandedToTheCanonicalForm) {
+  // The LD-V2200 reports five-digit HMMSS rather than the usual HMMSSFF. The
+  // application restores the zero frame field as it reads it, so its plans and
+  // reports can stay independent of the player model.
+  const DiscAddress address =
+      ParseAddress("00100\r", AddressMode::kTimeCode, TimeCodeFormat::kHMMSS);
+  EXPECT_TRUE(address.valid);
+  EXPECT_EQ(address.value, 10000);  // 0:01:00
+}
+
 TEST(ResponseParserTest, ZeroPaddingIsPaddingRatherThanWidth) {
   // Exactly what an LD-V4300D on the bench answers: seven zero-padded digits,
   // whatever the disc is. Counting the padding as significant would make every

--- a/ddd-gui/tests/support/fake_serial_port.h
+++ b/ddd-gui/tests/support/fake_serial_port.h
@@ -76,17 +76,16 @@ class FakeSerialPort : public ISerialPort {
   // watching a disc does not have to spell out the protocol. The Frame Register
   // query is the normal Level III default; a test of an LD-V2200-style player
   // explicitly selects its Time Register query instead.
-  void AddStatusResponses(uint32_t baud_rate, const std::string& active_mode,
-                          const std::string& disc_status,
-                          const std::string& address,
-                          PlayerCommand address_query =
-                              PlayerCommand::kQueryAddress) {
+  void AddStatusResponses(
+      uint32_t baud_rate, const std::string& active_mode,
+      const std::string& disc_status, const std::string& address,
+      PlayerCommand address_query = PlayerCommand::kQueryAddress) {
     AddResponse(baud_rate, "?P\r", active_mode + "\r");
     AddResponse(baud_rate, "?D\r", disc_status + "\r");
-    AddResponse(baud_rate,
-                address_query == PlayerCommand::kQueryTimeCode ? "?T\r"
-                                                                : "?F\r",
-                address + "\r");
+    AddResponse(
+        baud_rate,
+        address_query == PlayerCommand::kQueryTimeCode ? "?T\r" : "?F\r",
+        address + "\r");
   }
 
   // Every open fails, as a busy or absent port does.

--- a/ddd-gui/tests/support/fake_serial_port.h
+++ b/ddd-gui/tests/support/fake_serial_port.h
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "player_command.h"
 #include "serial_port.h"
 
 namespace ddd::player {
@@ -71,14 +72,21 @@ class FakeSerialPort : public ISerialPort {
     AddResponse(baud_rate, "?X\r", model_reply + "\r");
   }
 
-  // Answers to the three queries a status poll makes, so a test that wants a
-  // connected player watching a disc does not have to spell out the protocol.
+  // Answers to the status queries, so a test that wants a connected player
+  // watching a disc does not have to spell out the protocol. The Frame Register
+  // query is the normal Level III default; a test of an LD-V2200-style player
+  // explicitly selects its Time Register query instead.
   void AddStatusResponses(uint32_t baud_rate, const std::string& active_mode,
                           const std::string& disc_status,
-                          const std::string& address) {
+                          const std::string& address,
+                          PlayerCommand address_query =
+                              PlayerCommand::kQueryAddress) {
     AddResponse(baud_rate, "?P\r", active_mode + "\r");
     AddResponse(baud_rate, "?D\r", disc_status + "\r");
-    AddResponse(baud_rate, "?F\r", address + "\r");
+    AddResponse(baud_rate,
+                address_query == PlayerCommand::kQueryTimeCode ? "?T\r"
+                                                                : "?F\r",
+                address + "\r");
   }
 
   // Every open fails, as a busy or absent port does.

--- a/docs/content/capture-gui/player-control.md
+++ b/docs/content/capture-gui/player-control.md
@@ -419,6 +419,16 @@ differently because of it — it is a statement about evidence, and it is the ho
 "is my player supported?". A definition that has never met its hardware will be wrong
 somewhere, and the places it is wrong are exactly the ones nobody has looked at.
 
+On normal Pioneer Level III players, `?F` reads the Frame Register: a five-digit frame address
+on CAV and a frame-precise seven-digit `HMMSSFF` address on CLV. The LD-V2200 is the observed
+CLV exception: it refuses `?F` and reports its five-digit `HMMSS` time code through `?T`.
+Its definition sends a seek such as `TM00100SE` for 0:01:00 and converts a reply such as `00002`
+into the application's normal seven-digit `HMMSSFF` form. The remote disables Still for a known
+CLV disc, while retaining it for CAV and an unidentified disc. The LD-V2200 also returns `E04`
+to both user-code requests; until its meaning is confirmed, the report preserves that reply as
+refused rather than saying the disc has no user code. The definition remains unverified until the
+full hardware checklist has been completed.
+
 If you have one of these and are willing to walk the checklist, it is in
 [`ddd-gui/src/player/players/README.md`](https://github.com/simoninns/DomesdayDuplicator/blob/main/ddd-gui/src/player/players/README.md)
 and the full version is in TESTING.md §7. Adding a model is one header file and one line in


### PR DESCRIPTION
## Summary

Completes LD-V2200 CLV support while keeping the documented Pioneer Level III query behaviour for every other definition. Normal CLV players retain `?F`, which returns their frame-precise seven-digit `HMMSSFF` address. The LD-V2200 alone uses `?T`: it refuses `?F` on CLV and returns a five-digit `HMMSS` time code that the application normalizes to `HMMSSFF`.

It also prevents Still from being offered for known CLV discs, handles the LD-V2200's `E04` user-code replies conservatively as refused, and adds coverage and documentation for the model's protocol differences.

## Component

- Capture application (`ddd-gui`)
- Documentation (`docs/`)

## Type of change

- Bug fix

## Validation

- Original non-hardware validation: compiled and tested on Debian 13 (amd64); 1,865 non-hardware CTest tests passed, including all three full-duration functional soaks.
- Review correction: `git diff --check` and `./tools/check-licence-headers.sh` passed.
- CTest, format, and static checks were not rerun for the correction: this checkout is macOS and has neither the supported Nix environment nor an existing GUI build directory.
- Hardware validation was not run for this revision; no player is attached.

## Checklist

- [x] Scope is focused and minimal
- [x] Build passes locally
- [x] New source files carry the SPDX licence header — `./tools/check-licence-headers.sh`
- [x] Follows the conventions in [AGENTS.md](../AGENTS.md)
- [x] Related docs under [docs/content/](../docs/content/) were updated if needed
- [ ] Linked issue (if applicable)